### PR TITLE
fix: this fixes the issue on ios 17 

### DIFF
--- a/TcpSocket.js
+++ b/TcpSocket.js
@@ -38,7 +38,7 @@ function TcpSocket(options: ?{ id: ?number }) {
     this._id = instances++;
   }
 
-  this._eventEmitter = new NativeEventEmitter();
+  this._eventEmitter = new NativeEventEmitter(Sockets);
   stream.Duplex.call(this, {});
 
   // ensure compatibility with node's EventEmitter


### PR DESCRIPTION
ERROR: new NativeEventEmitter() was called with a non-null argument without the required removeListeners method 

Adding Sockets to the eventemmiter works in IOS